### PR TITLE
EWS Exchange: Updated library to fix vulnerabilities

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -4,7 +4,7 @@ Copyright (c) 2016-2022 Splunk Inc.
 Third-party Software Attributions:
 
 Library: Django
-Version: 3.2.10
+Version: 3.2.11
 License: BSD 3
 0.9.0 thru 1.2              1991-1995   CWI         yes
 1.3 thru 1.5.2  1.2         1995-1999   CNRI        yes

--- a/ewsonprem.json
+++ b/ewsonprem.json
@@ -26,7 +26,7 @@
         "wheel": [
             {
                 "module": "Django",
-                "input_file": "wheels/Django-3.2.10-py3-none-any.whl"
+                "input_file": "wheels/Django-3.2.11-py3-none-any.whl"
             },
             {
                 "module": "asgiref",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Django==3.2.10
+Django==3.2.11
 beautifulsoup4==4.9.1
 lxml==4.6.3
 ntlm_auth==1.0.5


### PR DESCRIPTION
The WhiteSource report was showing a vulnerability alert for the Django library version 3.2.10. Hence, upgraded the library to the 3.2.11 version.